### PR TITLE
Bug: Exit asynccontextmanager

### DIFF
--- a/src/glasses3/recordings/__init__.py
+++ b/src/glasses3/recordings/__init__.py
@@ -168,5 +168,7 @@ class Recordings(APIComponent):
     @asynccontextmanager
     async def keep_updated_in_context(self):
         await self.start_children_handler_tasks()
-        yield
-        await self.stop_children_handler_tasks()
+        try:
+            yield
+        finally:
+            await self.stop_children_handler_tasks()

--- a/src/glasses3/rudimentary.py
+++ b/src/glasses3/rudimentary.py
@@ -167,5 +167,7 @@ class Rudimentary(APIComponent):
     @asynccontextmanager
     async def keep_alive_in_context(self):
         await self.start_streams()
-        yield
-        await self.stop_streams()
+        try:
+            yield
+        finally:
+            await self.stop_streams()


### PR DESCRIPTION
The changed context managers would not execute the closedown if an error occurred in the context. 